### PR TITLE
Clear cached config when swapping .env

### DIFF
--- a/src/stubs/support/index.js
+++ b/src/stubs/support/index.js
@@ -19,8 +19,10 @@ import './assertions';
 
 before(() => {
     cy.task('activateCypressEnvFile', {}, {log: false});
+    cy.artisan('config:clear', {}, {log: false});
 });
 
 after(() => {
     cy.task('activateLocalEnvFile', {}, {log: false});
+    cy.artisan('config:clear', {}, {log: false});
 });


### PR DESCRIPTION
Suppressing the logs isn't currently supported by the laravel commands, but I think that should be a separate PR.