### PR TITLE
Fix failing test: add missing array offset

### DIFF
--- a/tests/CypressControllerTest.php
+++ b/tests/CypressControllerTest.php
@@ -64,7 +64,7 @@ class CypressControllerTest extends TestCase
 
         $this->assertDatabaseHas('users', ['name' => 'John Doe']);
 
-        $this->assertEquals('John Doe', $response->json()['name']);
+        $this->assertEquals('John Doe', $response->json()[0]['name']);
     }
 
     /** @test */


### PR DESCRIPTION
## What 
Currently the `it_generates_an_eloquent_model_using_a_factory` test fails on accessing an undefined index of the `$response->json()` array. 

```
...E......                                                        10 / 10 (100%)

Time: 1.27 minutes, Memory: 32.00 MB

There was 1 error:

1) Laracasts\Cypress\Tests\CypressControllerTest::it_generates_an_eloquent_model_using_a_factory
ErrorException: Undefined index: name
```

## What has been done
* Update `$response->json()['name']` to `$response->json()[0]['name']`. 

## Notes
The test below (`it_generates_a_collection_of_eloquent_model_using_a_factory`) was already using `$response->json()[0]['name']`.