### PR TITLE
Adding PHP8 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kraenkvisuell/cypress",
+    "name": "laracasts/cypress",
     "description": "Laravel Cypress Boilerplate",
     "keywords": [
         "laracasts",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laracasts/cypress",
+    "name": "kraenkvisuell/cypress",
     "description": "Laravel Cypress Boilerplate",
     "keywords": [
         "laracasts",
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": ">=7.3",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/tests/CypressControllerTest.php
+++ b/tests/CypressControllerTest.php
@@ -63,7 +63,7 @@ class CypressControllerTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('users', ['name' => 'John Doe']);
-        
+
         $this->assertEquals('John Doe', $response->json()[0]['name']);
     }
 

--- a/tests/CypressControllerTest.php
+++ b/tests/CypressControllerTest.php
@@ -63,8 +63,7 @@ class CypressControllerTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('users', ['name' => 'John Doe']);
-
-        $this->assertEquals('John Doe', $response->json()['name']);
+        $this->assertEquals('John Doe', $response->json()[0]['name']);
     }
 
     /** @test */

--- a/tests/CypressControllerTest.php
+++ b/tests/CypressControllerTest.php
@@ -63,6 +63,7 @@ class CypressControllerTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('users', ['name' => 'John Doe']);
+        
         $this->assertEquals('John Doe', $response->json()[0]['name']);
     }
 


### PR DESCRIPTION
Hi there - this seems to work when I run my cypress tests and the PHPUnit tests run too (I had to change one small thing in a test but that should have failed before my changes as well / had nothing to do with my changes, as far as I can see).

