### PR TITLE
Fix missing route error message

### DIFF
--- a/src/stubs/support/laravel-routes.js
+++ b/src/stubs/support/laravel-routes.js
@@ -4,7 +4,7 @@ Cypress.Laravel = {
     route: (name, parameters = {}) => {
         assert(
             Cypress.Laravel.routes.hasOwnProperty(name),
-            `Laravel route "${name}" exists.`
+            `Laravel route "${name}" does not exist.`
         );
 
         return ((uri) => {


### PR DESCRIPTION
It was confusing when I first got error message claiming that route exists.