### PR TITLE
Allow visit() options when using laravel routes

### DIFF
--- a/src/stubs/support/laravel-commands.js
+++ b/src/stubs/support/laravel-commands.js
@@ -102,6 +102,7 @@ Cypress.Commands.overwrite('visit', (originalFn, subject, options) => {
         return originalFn({
             url: Cypress.Laravel.route(subject.route, subject.parameters || {}),
             method: Cypress.Laravel.routes[subject.route].method[0],
+            ...options
         });
     }
 


### PR DESCRIPTION
Allows setting options to the visit() method, like failOnStatusCode, which allows testing 404 pages
```js
cy.visit({
    route: 'admin.brands.show',
    parameters: {brand: brand.id}
}, {failOnStatusCode: false})

cy.get('body').should('contain.text', 'Not Found')
```