### PR TITLE
Add Cypress 10 support

### DIFF
--- a/src/stubs/cypress.config.js
+++ b/src/stubs/cypress.config.js
@@ -1,0 +1,19 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+    chromeWebSecurity: false,
+    retries: 2,
+    defaultCommandTimeout: 5000,
+    watchForFileChanges: false,
+    videosFolder: '%cypressPath%/videos',
+    screenshotsFolder: '%cypressPath%/screenshots',
+    fixturesFolder: '%cypressPath%/fixture',
+    e2e: {
+        setupNodeEvents(on, config) {
+            return require('./%cypressPath%/plugins/index.js')(on, config)
+        },
+        baseUrl: '%baseUrl%',
+        specPattern: '%cypressPath%/integration/**/*.cy.{js,jsx,ts,tsx}',
+        supportFile: '%cypressPath%/support/index.js',
+    },
+})

--- a/src/stubs/integration/example.cy.js
+++ b/src/stubs/integration/example.cy.js
@@ -1,0 +1,7 @@
+describe('Example Test', () => {
+    it('shows a homepage', () => {
+        cy.visit('/');
+
+        cy.contains('Laravel');
+    });
+});


### PR DESCRIPTION
This PR adds support for Cypress 10. The latest version of Cypress adds a massive performance boost in comparison to Cypress 9.x.

The configuration file of Cypress changed in this update. Since the configuration file is now no longer a simple JSON object, I skipped the ability to upgrade existing configuration files – if the configuration file exists, users should manually modify it to load the plugins.

In addition to this, I added an example test so that the "onboarding" experience is more like Laravel Dusk. It's a simple test that just ensures that "Laravel" can be found on the default homepage. Pretty much what the example Dusk test is doing as well.