### PR TITLE
Add support for Cypress 10 while retaining support for older versions

### DIFF
--- a/src/stubs/cypress.config.js
+++ b/src/stubs/cypress.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require("cypress");
+
+module.exports = defineConfig({
+  downloadsFolder: '%cypressPath%/downloads',
+  videosFolder: '%cypressPath%/videos',
+  fixturesFolder: '%cypressPath%/fixtures',
+  screenshotsFolder: '%cypressPath%/screenshots',
+  supportFolder: '%cypressPath%/support',
+
+  e2e: {
+    setupNodeEvents(on, config) {
+      return require('./%cypressPath%/plugins/index.js')(on, config)
+    },
+    baseUrl: "%baseUrl%",
+    supportFile: '%cypressPath%/support/e2e.js',
+    specPattern: '%cypressPath%/e2e/**/*.cy.{js,jsx,ts,tsx}'
+  },
+});

--- a/src/stubs/support/e2e.js
+++ b/src/stubs/support/e2e.js
@@ -1,0 +1,32 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+/// <reference types="./" />
+
+import './laravel-commands';
+import './laravel-routes';
+import './assertions';
+
+before(() => {
+    cy.task('activateCypressEnvFile', {}, { log: false });
+    cy.artisan('config:clear', {}, { log: false });
+
+    cy.refreshRoutes();
+});
+
+after(() => {
+    cy.task('activateLocalEnvFile', {}, { log: false });
+    cy.artisan('config:clear', {}, { log: false });
+});


### PR DESCRIPTION
This PR adds support for Cypress 10 while retaining the support for older versions without any change in workflow.

It detects the installed version of cypress from the consuming app's package.json. If the installed version is older than 10, then this package works without any change (from earlier).

However if the installed cypress version is 10, it will copy a default `cypress.config.js` file if `--force` option is used. Otherwise it will ask the user for confirmation regarding - whether the config file should be overwritten and suggests to manually update the file if user chooses not to overwrite automatically.