### PR TITLE
remove non-used optional parameters from uri

### DIFF
--- a/src/stubs/support/laravel-routes.js
+++ b/src/stubs/support/laravel-routes.js
@@ -12,6 +12,10 @@ Cypress.Laravel = {
                 uri = uri.replace(
                     new RegExp(`{${parameter}}`),
                     parameters[parameter]
+                )
+                .replace(
+                    /\/{[a-zA-Z]+[?]}/,
+                    ''
                 );
             });
 


### PR DESCRIPTION
Optional parameters like e.g. 'name' in '/user/{name?}' need to be removed from uri if not used/empty, otherwise the assertion will fail.