### PR TITLE
Allow Configuration Of Which Env Routes Should Not Publish For

### DIFF
--- a/config/cypress.php
+++ b/config/cypress.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Environments
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the environment(s) your application should not configure
+    | the cypress routes for. You may list additional environments to prevent
+    | from getting included with your application.
+    |
+    | Default: 'production'
+    | Example: 'production','staging'
+    */
+
+    'exclude' => env('CYPRESS_EXCLUDED_ENV', 'production'),
+
+];

--- a/src/CypressServiceProvider.php
+++ b/src/CypressServiceProvider.php
@@ -9,7 +9,17 @@ class CypressServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        if ($this->app->environment('production')) {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/cypress.php', 'cypress'
+        );
+
+        $excludedEnvironments = config('cypress.exclude');
+        if (is_string($excludedEnvironments)) {
+            $excludedEnvironments = explode(',', $excludedEnvironments);
+        }
+        $excludedEnvironments[] = 'production';
+
+        if ($this->app->environment($excludedEnvironments)) {
             return;
         }
 


### PR DESCRIPTION
### The Problem
I am not able to adjust the added cypress routes based on environment (expect Production). When my  `APP_ENV` is set to `local` or something like `ci` that is fine to have those routes added, but some workflows have several testing and qa environments where these routes might not be appropriate for.

### What Exist Now
Currently, as defined in the `CypressServiceProvider` only when in the parent application (i.e. the app using the package) has its application environment `APP_ENV` set to `production` do the added Cypress routes not get published. To confirm this, you can change in your app:
```
APP_ENV=production
```
Then run `php artisan route:list | grep cypress` to see no results.
Alternatively you can have that set to local, or any other value and see a list of added cypress routes.

### Solution
Within this PR I have added a feature that will now check if the application has a `config/cypress.php` file and if any application environment names are listed in the `exclude` key, they will be treated similar to how production environment works now, and they will not be added.
This also makes sure that the production environment is always added regardless of config,

### Examples
Here I have an app which its `.env` & `config/cypress.php` look like the following:
> `.env`
```
APP_ENV=staging 
```
> `config/cypress.php`
```php
<?php
    'exclude' => 'production'
];
```
> Small note, you would't need to add `production` here, just to simplify example.

Given the following example I would see the following routes added
![image](https://user-images.githubusercontent.com/25044744/182531065-0c64c286-d146-42e0-9a09-71bf749d8f72.png)

Now if I update my `config/cypress.php` to include the `staging` environment too, then re-run command, I should not see the routes listed anymore.

