### PR TITLE
Update index.d.ts: Add create parameters

### DIFF
--- a/src/stubs/support/index.d.ts
+++ b/src/stubs/support/index.d.ts
@@ -52,7 +52,7 @@ declare namespace Cypress {
          * cy.create('App\\User', 2, { active: false });
          * cy.create({ model: 'App\\User', state: ['guest'], relations: ['profile'], count: 2 }
          */
-        create(): Chainable<any>;
+        create(model: string, count?: number | object | string[] | null, attributes?: object, load?: string[], state?: string[]): Chainable<any>;
 
         /**
          * Refresh the database state using Laravel's migrate:fresh command.


### PR DESCRIPTION
Create does not have any parameter definitions. This causes linting errors when calling the method with arguments.

For example, the below throws the lint error: `Expected 0 arguments, but got 2`
```
cy.create('App\\Models\\User', {
  email: 'janedoe@example.com',
});
```
We can see from `src/stubs/support/laravel-commands.js` that create in fact has multiple arguments/parameters:
`Cypress.Commands.add('create', (model, count = 1, attributes = {}, load = [], state = []) => {`

This small PR adds type definitions to the index.d.ts file.