### PR TITLE
Using factories by morph name

### DIFF
--- a/src/Controllers/CypressController.php
+++ b/src/Controllers/CypressController.php
@@ -2,6 +2,7 @@
 
 namespace Laracasts\Cypress\Controllers;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
@@ -121,6 +122,7 @@ class CypressController
 
     protected function factoryBuilder($model, $states = [])
     {
+        $model = Relation::getMorphedModel($model) ?? $model;
         $factory = $model::factory();
 
         $states = Arr::wrap($states);

--- a/tests/CypressControllerTest.php
+++ b/tests/CypressControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Laracasts\Cypress\Tests;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Laracasts\Cypress\CypressServiceProvider;
@@ -123,6 +124,28 @@ class CypressControllerTest extends TestCase
             ],
             'load' => ['profile'],
             'state' => ['guest']
+        ]);
+
+        $this->assertDatabaseHas('users', ['name' => 'John Doe']);
+        $this->assertEquals('John Doe', $response->json()['name']);
+        $this->assertEquals('USA', $response->json()['profile']['location']);
+        $this->assertEquals('guest', $response->json()['plan']);
+    }
+
+    /** @test */
+    public function it_builds_a_model_factory_by_its_morph_name()
+    {
+        Relation::morphMap([
+            'test_user' => TestUser::class,
+        ]);
+
+        $response = $this->post(route('cypress.factory'), [
+            'model' => 'test_user',
+            'attributes' => [
+                'name' => 'John Doe',
+            ],
+            'load' => ['profile'],
+            'state' => ['guest'],
         ]);
 
         $this->assertDatabaseHas('users', ['name' => 'John Doe']);


### PR DESCRIPTION
Hello, 

this is the PR for issue #50, I got no response on the issue so I figured I might as well try a PR directly.

This PR adds support for using factories by Eloquent model morph name.

```
cy.create('App\\Models\\User', { email: 'test@example.com' });
```

can be a little more simplified and more straightforward to type

```
cy.create('user', { email: 'test@example.com' });

cy.create({
    model: 'user',
    attributes: { email: 'test@example.com' },
    count: 10
})
```

Feel free to close it if it's not something you want in the package.

Thank you!