### PR TITLE
Fix for optional route parameters

### DIFF
--- a/src/stubs/support/laravel-routes.js
+++ b/src/stubs/support/laravel-routes.js
@@ -10,7 +10,7 @@ Cypress.Laravel = {
         return ((uri) => {
             Object.keys(parameters).forEach((parameter) => {
                 uri = uri.replace(
-                    new RegExp(`{${parameter}}`),
+                    new RegExp(`{${parameter}\\?\?}`),
                     parameters[parameter]
                 );
             });


### PR DESCRIPTION
Updates `Cypress.Laravel.route()` to add support for [optional route parameters](https://laravel.com/docs/10.x/routing#parameters-optional-parameters), e.g. those ending with `?` for example `/user/{name?}`