### PR TITLE
Fixed message for asserting route exists

### DIFF
--- a/src/stubs/support/laravel-routes.js
+++ b/src/stubs/support/laravel-routes.js
@@ -4,7 +4,7 @@ Cypress.Laravel = {
     route: (name, parameters = {}) => {
         assert(
             Cypress.Laravel.routes.hasOwnProperty(name),
-            `Laravel route "${name}" does not exist.`
+            `Laravel route "${name}" exists.`
         );
 
         return ((uri) => {


### PR DESCRIPTION
The real issue is the actual message. Cypress displays all expectation, in green when they are successful and in red when they fail. Compare
<img width="257" alt="Screenshot 2024-11-25 at 16 33 55" src="https://github.com/user-attachments/assets/6da26b21-ef24-4242-9c0b-3cce633295ff">
and
<img width="308" alt="Screenshot 2024-11-25 at 16 33 17" src="https://github.com/user-attachments/assets/c15bd257-228f-450f-9419-7937f7f10425">

So, as @Joucke said in this [comment](https://github.com/laracasts/cypress/issues/55#issuecomment-1296971741), what's displayed should be what the package is trying to assert, i.e. that the route exists. 

This PR does just that, so now we would have

<img width="295" alt="Screenshot 2024-11-25 at 16 41 24" src="https://github.com/user-attachments/assets/e6ce32e0-0e4c-443a-9802-b6aba0f579c0">

and 

<img width="296" alt="Screenshot 2024-11-25 at 16 41 48" src="https://github.com/user-attachments/assets/7ebc59f2-d3ef-461b-a198-36af79c36c38">

Closes #55 